### PR TITLE
Add basic player scene skeleton

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,5 +11,6 @@ config_version=5
 [application]
 
 config/name="first_game"
+run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,0 +1,7 @@
+[gd_scene format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/player.tscn" id="1"]
+
+[node name="Main" type="Node"]
+
+[node name="Player" parent="." instance=ExtResource("1")]

--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3]
+
+[ext_resource type="Script" path="res://scripts/player.gd" id="1"]
+
+[node name="Player" type="CharacterBody2D"]
+script = ExtResource("1")

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -1,0 +1,16 @@
+extends CharacterBody2D
+
+@export var speed := 300.0
+@export var jump_velocity := -400.0
+@export var gravity := 1200.0
+
+func _physics_process(delta: float) -> void:
+    var direction := Input.get_axis("ui_left", "ui_right")
+    velocity.x = direction * speed
+
+    if not is_on_floor():
+        velocity.y += gravity * delta
+    elif Input.is_action_just_pressed("ui_up"):
+        velocity.y = jump_velocity
+
+    move_and_slide()


### PR DESCRIPTION
## Summary
- configure `project.godot` to launch a new `Main` scene
- add a simple `CharacterBody2D` player script
- create minimal Player and Main scenes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841ce536a58832597c8faf0ab0a3602