### PR TITLE
Add simple HUD and inventory UI

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -49,6 +49,10 @@ jump={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
 ]
 }
+open_inventory={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":73,"key_label":0,"unicode":105,"location":0,"echo":false,"script":null)]
+}
 
 [rendering]
 

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://citgr4h7kjmw2"]
+[gd_scene load_steps=18 format=3 uid="uid://citgr4h7kjmw2"]
 
 [ext_resource type="PackedScene" uid="uid://dolm0awkrgl7m" path="res://scenes/player.tscn" id="1"]
 [ext_resource type="Script" uid="uid://bo8rt7s20wgyr" path="res://scripts/world_map.gd" id="1_3p2gp"]
@@ -15,6 +15,7 @@
 [ext_resource type="PackedScene" uid="uid://jubqgarq03kq" path="res://scenes/fog_layer.tscn" id="12_bjd11"]
 [ext_resource type="Shader" uid="uid://cq0tvmh3a0lof" path="res://shaders/god_rays.gdshader" id="13_qmy6f"]
 [ext_resource type="TileSet" uid="uid://cx0ix7fgfoa71" path="res://assets/tilesets/world_tiles.tres" id="14_mwfav"]
+[ext_resource type="Script" path="res://scripts/hud.gd" id="15_hud"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_mwfav"]
 shader = ExtResource("13_qmy6f")
@@ -152,3 +153,68 @@ grow_vertical = 2
 position = Vector2(-591, -480)
 tile_set = ExtResource("14_mwfav")
 use_kinematic_bodies = true
+
+[node name="HUDLayer" type="CanvasLayer" parent="."]
+script = ExtResource("15_hud")
+
+[node name="HUD" type="Control" parent="HUDLayer"]
+
+[node name="HealthBar" type="ProgressBar" parent="HUD"]
+anchors_preset = 0
+anchor_right = 0.3
+show_percentage = false
+
+[node name="ManaBar" type="ProgressBar" parent="HUD"]
+anchors_preset = 0
+anchor_top = 0.1
+anchor_bottom = 0.1
+anchor_right = 0.3
+offset_top = 20.0
+show_percentage = false
+
+[node name="QuickSlots" type="HBoxContainer" parent="HUD"]
+anchors_preset = 8
+anchor_left = 0.25
+anchor_right = 0.75
+anchor_bottom = 1.0
+offset_bottom = -10.0
+[node name="Slot1" type="TextureRect" parent="HUD/QuickSlots"]
+[node name="Slot2" type="TextureRect" parent="HUD/QuickSlots"]
+[node name="Slot3" type="TextureRect" parent="HUD/QuickSlots"]
+[node name="Slot4" type="TextureRect" parent="HUD/QuickSlots"]
+[node name="Slot5" type="TextureRect" parent="HUD/QuickSlots"]
+[node name="Slot6" type="TextureRect" parent="HUD/QuickSlots"]
+[node name="Slot7" type="TextureRect" parent="HUD/QuickSlots"]
+[node name="Slot8" type="TextureRect" parent="HUD/QuickSlots"]
+[node name="Slot9" type="TextureRect" parent="HUD/QuickSlots"]
+[node name="Slot10" type="TextureRect" parent="HUD/QuickSlots"]
+
+[node name="InventoryPanel" type="Panel" parent="HUD"]
+visible = false
+anchors_preset = 15
+anchor_left = 0.25
+anchor_top = 0.25
+anchor_right = 0.75
+anchor_bottom = 0.75
+
+[node name="InventoryGrid" type="GridContainer" parent="HUD/InventoryPanel"]
+columns = 5
+[node name="InvSlot1" type="TextureRect" parent="HUD/InventoryPanel/InventoryGrid"]
+[node name="InvSlot2" type="TextureRect" parent="HUD/InventoryPanel/InventoryGrid"]
+[node name="InvSlot3" type="TextureRect" parent="HUD/InventoryPanel/InventoryGrid"]
+[node name="InvSlot4" type="TextureRect" parent="HUD/InventoryPanel/InventoryGrid"]
+[node name="InvSlot5" type="TextureRect" parent="HUD/InventoryPanel/InventoryGrid"]
+[node name="InvSlot6" type="TextureRect" parent="HUD/InventoryPanel/InventoryGrid"]
+[node name="InvSlot7" type="TextureRect" parent="HUD/InventoryPanel/InventoryGrid"]
+[node name="InvSlot8" type="TextureRect" parent="HUD/InventoryPanel/InventoryGrid"]
+[node name="InvSlot9" type="TextureRect" parent="HUD/InventoryPanel/InventoryGrid"]
+[node name="InvSlot10" type="TextureRect" parent="HUD/InventoryPanel/InventoryGrid"]
+
+[node name="MiniMap" type="TextureRect" parent="HUD"]
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 0.0
+offset_left = -150
+offset_top = 10
+custom_minimum_size = Vector2(140, 80)
+

--- a/scripts/hud.gd
+++ b/scripts/hud.gd
@@ -1,0 +1,25 @@
+extends CanvasLayer
+
+@onready var inventory_panel: Control = $HUD/InventoryPanel
+@onready var health_bar: ProgressBar = $HUD/HealthBar
+@onready var mana_bar: ProgressBar = $HUD/ManaBar
+
+func _ready() -> void:
+    var player = get_parent().get_node("Player")
+    if player:
+        if player.has_signal("health_changed"):
+            player.health_changed.connect(_on_player_health_changed)
+        if player.has_signal("mana_changed"):
+            player.mana_changed.connect(_on_player_mana_changed)
+
+func _process(_delta: float) -> void:
+    if Input.is_action_just_pressed("open_inventory"):
+        inventory_panel.visible = not inventory_panel.visible
+
+func _on_player_health_changed(value: int, max_value: int) -> void:
+    health_bar.max_value = max_value
+    health_bar.value = value
+
+func _on_player_mana_changed(value: int, max_value: int) -> void:
+    mana_bar.max_value = max_value
+    mana_bar.value = value

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -4,16 +4,25 @@ extends CharacterBody2D
 @export var jump_velocity := -400.0
 @export var gravity := 1200.0
 @export var attack_cooldown := 0.2
+@export var max_health := 100
+@export var max_mana := 50
+
+signal health_changed(value: int, max_value: int)
+signal mana_changed(value: int, max_value: int)
 
 @onready var attack_area: Area2D = $AttackArea
 @onready var attack_animation: GPUParticles2D = $AttackAnimation
 
 var _attack_timer := 0.0
 var _is_attacking := false
+var health := max_health
+var mana := max_mana
 
 func _ready() -> void:
-	attack_area.monitoring = false
-	attack_area.area_entered.connect(_on_attack_area_entered)
+        attack_area.monitoring = false
+        attack_area.area_entered.connect(_on_attack_area_entered)
+        emit_signal("health_changed", health, max_health)
+        emit_signal("mana_changed", mana, max_mana)
 
 func _physics_process(delta: float) -> void:
 	var direction := Input.get_axis("move_left", "move_right")
@@ -42,5 +51,13 @@ func perform_attack() -> void:
 	attack_area.monitoring = true
 
 func _on_attack_area_entered(area: Area2D) -> void:
-	if area.has_method("take_damage"):
-		area.take_damage(1)
+        if area.has_method("take_damage"):
+                area.take_damage(1)
+
+func take_damage(amount: int) -> void:
+        health = clamp(health - amount, 0, max_health)
+        emit_signal("health_changed", health, max_health)
+
+func use_mana(amount: int) -> void:
+        mana = clamp(mana - amount, 0, max_mana)
+        emit_signal("mana_changed", mana, max_mana)


### PR DESCRIPTION
## Summary
- add player health and mana to `player.gd`
- add HUD script that toggles inventory and updates health/mana bars
- add CanvasLayer to `Main.tscn` with quick slots, inventory panel, and minimap
- map `open_inventory` action to `I`

## Testing
- `gdformat --version` *(fails: command not found)*
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f84ba11c832590bc4e031ea87584