### PR TITLE
Set tilemap to static bodies

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -199,7 +199,7 @@ grow_vertical = 2
 [node name="WorldMap" type="TileMapLayer" parent="."]
 position = Vector2(-591, -480)
 tile_set = ExtResource("14_mwfav")
-use_kinematic_bodies = true
+use_kinematic_bodies = false
 
 [node name="HUDLayer" type="CanvasLayer" parent="."]
 script = ExtResource("15_hud")


### PR DESCRIPTION
## Summary
- disable use_kinematic_bodies on the WorldMap TileMapLayer in the Main scene

## Testing
- `godot` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443a06c96c83258a8a78db014cccca