### PR TITLE
Add QuickSlots script for item selection

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=27 format=3 uid="uid://citgr4h7kjmw2"]
+[gd_scene load_steps=28 format=3 uid="uid://citgr4h7kjmw2"]
 
 [ext_resource type="PackedScene" uid="uid://dolm0awkrgl7m" path="res://scenes/player.tscn" id="1"]
 [ext_resource type="Script" uid="uid://bo8rt7s20wgyr" path="res://scripts/world_map.gd" id="1_3p2gp"]
@@ -19,6 +19,7 @@
 [ext_resource type="Script" uid="uid://bqb1l0y2cyjop" path="res://scripts/mini_map_viewport.gd" id="17_ft6cd"]
 [ext_resource type="Texture2D" uid="uid://dn0qptp3d5uhe" path="res://assets/ui/minimap.png" id="18_bb450"]
 [ext_resource type="Script" uid="uid://cspwhrut3nv8d" path="res://scripts/inventory.gd" id="19_inv"]
+[ext_resource type="Script" path="res://scripts/quick_slots.gd" id="20_qs"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_mwfav"]
 shader = ExtResource("13_qmy6f")
@@ -249,6 +250,7 @@ anchor_right = 0.75
 anchor_bottom = 1.0
 offset_left = 186.5
 offset_right = 186.5
+script = ExtResource("20_qs")
 
 [node name="Slot1" type="TextureRect" parent="HUDLayer/HUD/QuickSlots"]
 layout_mode = 2

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -25,8 +25,8 @@ var mana := max_mana
 # Reference to the world map script (parent node)
 @onready var world_map := get_parent()
 
-# Currently selected quick-slot index
-var selected_slot: int = 0
+# Reference to the quick slots controller
+@onready var quick_slots: QuickSlots = get_parent().get_node("HUDLayer/HUD/QuickSlots")
 
 func _ready() -> void:
 		attack_area.monitoring = false
@@ -78,8 +78,8 @@ func use_mana(amount: int) -> void:
                emit_signal("mana_changed", mana, max_mana)
 
 func _get_selected_item() -> Item:
-       if inventory and selected_slot >= 0 and selected_slot < inventory.items.size():
-               return inventory.items[selected_slot]
+       if quick_slots:
+               return quick_slots.get_selected_item()
        return null
 
 func _use_selected_item() -> void:
@@ -99,4 +99,4 @@ func _place_selected_block() -> void:
        if item is BlockItem:
                var cell := world_map.position_to_cell(get_global_mouse_position())
                world_map.place_block(cell, item.terrain_id)
-               inventory.remove_item(selected_slot)
+               inventory.remove_item(quick_slots.selected_index)

--- a/scripts/quick_slots.gd
+++ b/scripts/quick_slots.gd
@@ -1,0 +1,45 @@
+extends HBoxContainer
+
+class_name QuickSlots
+
+@export var inventory_path: NodePath = NodePath("../../Inventory")
+@export var highlight_color: Color = Color.YELLOW
+@export var normal_color: Color = Color.WHITE
+
+@onready var inventory: Inventory = get_node(inventory_path)
+
+var selected_index: int = 0
+
+func _ready() -> void:
+        _update_highlight()
+
+func _input(event: InputEvent) -> void:
+        if event is InputEventKey and event.pressed and not event.echo:
+                match event.keycode:
+                        KEY_1: _select_slot(0)
+                        KEY_2: _select_slot(1)
+                        KEY_3: _select_slot(2)
+                        KEY_4: _select_slot(3)
+                        KEY_5: _select_slot(4)
+                        KEY_6: _select_slot(5)
+                        KEY_7: _select_slot(6)
+                        KEY_8: _select_slot(7)
+                        KEY_9: _select_slot(8)
+                        KEY_0: _select_slot(9)
+
+func _select_slot(index: int) -> void:
+        index = clamp(index, 0, get_child_count() - 1)
+        if selected_index == index:
+                return
+        selected_index = index
+        _update_highlight()
+
+func _update_highlight() -> void:
+        for i in range(get_child_count()):
+                var slot = get_child(i)
+                slot.modulate = highlight_color if i == selected_index else normal_color
+
+func get_selected_item() -> Item:
+        if inventory and selected_index >= 0 and selected_index < inventory.items.size():
+                return inventory.items[selected_index]
+        return null


### PR DESCRIPTION
## Summary
- add a new `QuickSlots` script
- attach the script to the `QuickSlots` node in `Main.tscn`
- let `player.gd` access the quick slots controller
- expose the selected item for mining and placing blocks

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444f23c5fc8325af0d1a606613fba7