### PR TITLE
Add use_item input action and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# First Game
+
+This repository contains a Godot project. Below are the default input actions defined in `project.godot`:
+
+- **attack**: `J` key or Left Mouse Button
+- **move_left**: `A` key
+- **move_right**: `D` key
+- **jump**: `Space` key
+- **open_inventory**: `I` key
+- **use_item**: `E` key
+- **place_block**: Right Mouse Button
+
+These bindings can be adjusted in the Godot project settings under `Input Map`.

--- a/project.godot
+++ b/project.godot
@@ -58,6 +58,10 @@ open_inventory={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":73,"key_label":0,"unicode":105,"location":0,"echo":false,"script":null)
 ]
 }
+use_item={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)]
+}
 place_block={
 "deadzone": 0.2,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)]


### PR DESCRIPTION
## Summary
- add a `use_item` action bound to the `E` key
- document default controls in a new README

## Testing
- `godot3 --version`

------
https://chatgpt.com/codex/tasks/task_e_68445019015c8325924bc36155f05b5a