### PR TITLE
Fix missing plugin reference

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -25,7 +25,7 @@ window/stretch/mode="canvas_items"
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/BurstParticles2D/plugin.cfg")
+enabled=PackedStringArray()
 
 [input]
 


### PR DESCRIPTION
## Summary
- remove unused plugin from project.godot

## Testing
- `gdlint scripts/player.gd | head -n 2`
- `gdlint scripts/world_map.gd | head -n 1`

------
https://chatgpt.com/codex/tasks/task_e_68445731a5dc832599d8ee935dce5a9d