### PR TITLE
Fix else-if in health orb shader

### DIFF
--- a/shaders/health_orb.gdshader
+++ b/shaders/health_orb.gdshader
@@ -81,13 +81,13 @@ void fragment() {
 
 				float oH = oheight;
 
-				if ((1. - oH) < UV.y) { 
+                               if ((1. - oH) < UV.y) {
 
-					COLOR = vec4(water_color)*0.5;
-				} else if ((1. - oH) < UV.y) { 
+                                       COLOR = vec4(water_color)*0.5;
+                               } else if ((1. - oH) <= UV.y) {
 
-					COLOR = vec4(water_color*water_back_lightness)*0.5;
-				} else {
+                                       COLOR = vec4(water_color*water_back_lightness)*0.5;
+                               } else {
 
 					COLOR = vec4(water_color.rgb, 1.0);
 				}


### PR DESCRIPTION
## Summary
- fix duplicated `else if` condition in `health_orb.gdshader`

## Testing
- `godot` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_684caf7ac0208325856caaaf3e2bf0d9