### PR TITLE
Improve orb response and visuals

### DIFF
--- a/scenes/orb_bar.tscn
+++ b/scenes/orb_bar.tscn
@@ -30,6 +30,7 @@ shader_parameter/vibration_magnitude = 1.29
 shader_parameter/vibration_wave_ci = 0.31
 shader_parameter/refraction_ratio_glass = 0.0
 shader_parameter/refraction_ratio_water = 0.0
+shader_parameter/transparent_empty = true
 
 [node name="OrbBar" type="Node2D"]
 script = ExtResource("1_ctuxr")

--- a/scripts/hud.gd
+++ b/scripts/hud.gd
@@ -26,19 +26,22 @@ func _ready() -> void:
 	hp_orb.SetShader(hp_material)
 	hp_orb.ball_color = Color(1, 1, 1, 1)
 	hp_orb.alert_ball_color = Color(1, 0.3, 0.1, 1)
-	hp_orb.Reset()
-	hp_material.set_shader_parameter("water_color", Color(1, 0.3, 0.3, 1))
+        hp_orb.Reset()
+        hp_material.set_shader_parameter("water_color", Color(1, 0.3, 0.3, 1))
+        hp_material.set_shader_parameter("transparent_empty", true)
 
 	var mp_material: ShaderMaterial = orb_mp_sprite.material.duplicate()
 	orb_mp_sprite.material = mp_material
 
-	mp_orb = OrbUIController.new()
-	mp_orb.SetOwner(self)
-	mp_orb.SetShader(mp_material)
-	mp_orb.ball_color = Color(1, 1, 1, 1)
-	mp_orb.alert_ball_color = Color(0.2, 0.2, 1.0, 1)
-	mp_orb.Reset()
-	mp_material.set_shader_parameter("water_color", Color(0.2, 0.5, 1, 1))
+        mp_orb = OrbUIController.new()
+        mp_orb.SetOwner(self)
+        mp_orb.SetShader(mp_material)
+        mp_orb.ball_color = Color(1, 1, 1, 1)
+        mp_orb.alert_ball_color = Color(0.2, 0.2, 1.0, 1)
+        mp_orb.Reset()
+        mp_orb.SetDeathStateEnabled(false)
+        mp_material.set_shader_parameter("water_color", Color(0.2, 0.5, 1, 1))
+        mp_material.set_shader_parameter("transparent_empty", true)
 
 	# === Подключение сигналов после инициализации орбов ===
 	if player:

--- a/shaders/health_orb.gdshader
+++ b/shaders/health_orb.gdshader
@@ -6,6 +6,8 @@ uniform bool light_effect = false;
 uniform bool border_exclusion_effect = false;
 uniform bool wave_fix_on_border = false;
 
+uniform bool transparent_empty = false;
+
 uniform vec4 water_color: source_color = vec4(1, 0, 0, 1);
 uniform float water_wave_speed : hint_range(-100, 100, 0.01) = 2;
 uniform float water_wave_ci: hint_range(0, 2, 0.01) = 0.05;
@@ -55,6 +57,11 @@ vec2 shiftuv(vec2 uv, float shiftratio) {
 }
 
 void fragment() {
+    if (transparent_empty && height <= 0.0 && oheight <= 0.0) {
+        COLOR = vec4(0.0);
+        return;
+    }
+
     float NTIME = vibration_effect ? TIME + vibration_time : TIME + vibration_effect_timelength;
 
     vec2 uv = (UV - 0.5) * 0.5;


### PR DESCRIPTION
## Summary
- allow disabling orb death state and store base water color
- hide orbs when empty via shader parameter `transparent_empty`
- avoid null references and create tweens safely in `OrbUIController`
- disable death state for mana orb and ensure transparent orbs

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cb52c293083259543c812ca9e0d56