### PR TITLE
Improve scene transitions

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,7 @@ boot_splash/show_image=false
 [autoload]
 
 TerrainData="*res://scripts/terrain_data.gd"
+TransitionManager="*res://scripts/transition_manager.gd"
 
 [display]
 

--- a/scenes/Levels/kingdom_holl.gd
+++ b/scenes/Levels/kingdom_holl.gd
@@ -1,17 +1,14 @@
 extends Node2D
 
 func _ready() -> void:
-	var player = $Player/Player
-	var camera = player.get_node("Camera2D")
-	var spawn_point_node = $EntranceRight
-	var spawn_position = spawn_point_node.position
-	var fade_rect = $FX/Fade
-
-	$RightExit.monitoring = false
-	fade_rect.visible = true
-	fade_rect.modulate.a = 1.0
-
-	if spawn_position:
+var player = $Player/Player
+		var camera = player.get_node("Camera2D")
+		var spawn_point_node = $EntranceRight
+		var spawn_position = spawn_point_node.position
+		
+		$RightExit.monitoring = false
+		
+		if spawn_position:
 		# Ставим игрока на позицию заранее
 		player.position = spawn_position + Vector2(100, 0)
 		player.set_process(false)
@@ -21,32 +18,23 @@ func _ready() -> void:
 		
 		# Сбрасываем сглаживание, чтобы камера встала сразу на позицию игрока, без дерганий
 		if camera.position_smoothing_enabled:
-			camera.reset_smoothing()
-
+		camera.reset_smoothing()
+		
 		var tween = get_tree().create_tween()
-
-		tween.tween_property(fade_rect, "modulate:a", 0.0, 1.5)
 		tween.tween_property(player, "position", spawn_position, 1.0)
 		tween.tween_callback(Callable(self, "_enable_transition_and_player"))
-	else:
+		else:
 		player.position = Vector2(100, 100)
-
-func _enable_transition_and_player():
+		
+	func _enable_transition_and_player():
 	var player = $Player/Player
 	player.set_process(true)
 	$RightExit.monitoring = true
-
 	
-func _on_right_exit_body_entered(body: Node2D) -> void:
+	func _on_right_exit_body_entered(body: Node2D) -> void:
 	if body.name == "Player":
-		var fade_rect = $FX/Fade
-		fade_rect.visible = true
-		fade_rect.modulate.a = 0.0
-		var tween = get_tree().create_tween()
-		tween.tween_property(fade_rect, "modulate:a", 1.0, 0.5)
-		body.set_process(false)
-		tween.tween_property(body, "position:x", body.position.x + 100, 1.0)
-		tween.tween_callback(Callable(self, "_load_next_scene"))
-
-func _load_next_scene():
-	get_tree().change_scene_to_file("res://scenes/Levels/kingdom_king.tscn")
+	body.set_process(false)
+	TransitionManager.change_scene("res://scenes/Levels/kingdom_king.tscn")
+	
+	func _load_next_scene():
+	pass

--- a/scenes/Levels/kingdom_king.gd
+++ b/scenes/Levels/kingdom_king.gd
@@ -2,40 +2,34 @@ extends Node2D
 
 
 func _ready() -> void:
-	var player = $Player
-	var spawn_point_node = $Entrance
-	var spawn_position = spawn_point_node.position
-
-	$Exit.monitoring = false # отключить зону выхода
-
-	if spawn_position:
-		player.position = spawn_position + Vector2(0.0, 100.0)
-		player.set_process(false)
-
-		var tween = get_tree().create_tween()
-		tween.tween_property(player, "position", spawn_position, 1.0)
-		tween.tween_callback(Callable(self, "_enable_transition_and_player"))
-	else:
-		player.position = Vector2(100.0, 100.0)
-
-
-func _enable_transition_and_player():
-	var player = $Player
-	player.set_process(true)
-	$Exit.monitoring = true
-
-
-func _on_exit_body_entered(body: Node2D) -> void:
-	if body.name == "Player":
-		var fade_rect = $FX/Fade
-		fade_rect.visible = true
-		fade_rect.modulate.a = 0.0
-		var tween = get_tree().create_tween()
-		tween.tween_property(fade_rect, "modulate:a", 1.0, 0.5)
-		body.set_process(false)
-		tween.tween_property(body, "position:x", body.position.x + 100, 1.0)
-		tween.tween_callback(Callable(self, "_load_next_scene"))
-
-
-func _load_next_scene():
-	get_tree().change_scene_to_file("res://scenes/Levels/kingdom_holl.tscn")
+		var player = $Player
+		var spawn_point_node = $Entrance
+		var spawn_position = spawn_point_node.position
+	
+		$Exit.monitoring = false # отключить зону выхода
+	
+		if spawn_position:
+			player.position = spawn_position + Vector2(0.0, 100.0)
+			player.set_process(false)
+	
+			var tween = get_tree().create_tween()
+			tween.tween_property(player, "position", spawn_position, 1.0)
+			tween.tween_callback(Callable(self, "_enable_transition_and_player"))
+		else:
+			player.position = Vector2(100.0, 100.0)
+	
+	
+	func _enable_transition_and_player():
+		var player = $Player
+		player.set_process(true)
+		$Exit.monitoring = true
+	
+	
+	func _on_exit_body_entered(body: Node2D) -> void:
+		if body.name == "Player":
+			body.set_process(false)
+			TransitionManager.change_scene("res://scenes/Levels/kingdom_holl.tscn")
+	
+	
+	func _load_next_scene():
+		pass

--- a/scripts/transition_manager.gd
+++ b/scripts/transition_manager.gd
@@ -1,0 +1,24 @@
+extends CanvasLayer
+class_name TransitionManager
+
+var fade_rect: ColorRect
+	
+	func _ready() -> void:
+	fade_rect = ColorRect.new()
+	fade_rect.color = Color.BLACK
+	fade_rect.anchor_right = 1.0
+	fade_rect.anchor_bottom = 1.0
+	fade_rect.visible = false
+	add_child(fade_rect)
+	
+	func change_scene(scene_path: String) -> void:
+	fade_rect.visible = true
+	fade_rect.modulate.a = 0.0
+	var tween = get_tree().create_tween()
+	tween.tween_property(fade_rect, "modulate:a", 1.0, 0.5)
+	await tween.finished
+	get_tree().change_scene_to_file(scene_path)
+	tween = get_tree().create_tween()
+	tween.tween_property(fade_rect, "modulate:a", 0.0, 0.5)
+	await tween.finished
+	fade_rect.visible = false


### PR DESCRIPTION
## Summary
- implement TransitionManager for smoother fade-based scene changes
- use TransitionManager in kingdom_holl and kingdom_king
- register TransitionManager as an autoload singleton

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853265d11508325b14024f26825d571