### PR TITLE
Add pantheon altar interaction

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -20,6 +20,7 @@ boot_splash/show_image=false
 
 TerrainData="*res://scripts/terrain_data.gd"
 TransitionManager="*res://scripts/transition_manager.gd"
+BlessingManager="*res://scripts/blessing_manager.gd"
 
 [display]
 

--- a/scenes/altar.tscn
+++ b/scenes/altar.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/god_altar.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_1"]
+extents = Vector2(16, 16)
+
+[node name="Altar" type="Area2D"]
+script = ExtResource("1")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_1")

--- a/scripts/blessing_manager.gd
+++ b/scripts/blessing_manager.gd
@@ -1,0 +1,13 @@
+extends Node
+class_name BlessingManager
+
+var blessings: Dictionary = {}
+
+func set_blessing(god_name: String, blessing: String) -> void:
+        blessings[god_name] = blessing
+
+func get_blessing(god_name: String) -> String:
+        return blessings.get(god_name, "")
+
+func clear() -> void:
+        blessings.clear()

--- a/scripts/god_altar.gd
+++ b/scripts/god_altar.gd
@@ -1,0 +1,30 @@
+extends Area2D
+class_name GodAltar
+
+@export var god_name: String = "God"
+@export var blessings: Array[String] = ["Blessing1", "Blessing2"]
+
+signal blessing_selected(god: String, blessing: String)
+
+func interact(_player: Node) -> void:
+        _show_menu()
+
+func _show_menu() -> void:
+        var win := Window.new()
+        win.title = "Выберите благословение"
+        var vbox := VBoxContainer.new()
+        win.add_child(vbox)
+        for b in blessings:
+                var btn := Button.new()
+                btn.text = b
+                btn.pressed.connect(_on_blessing_chosen.bind(b, win))
+                vbox.add_child(btn)
+        add_child(win)
+        get_tree().paused = true
+        win.popup_centered(Vector2(200, 100))
+
+func _on_blessing_chosen(blessing: String, win: Window) -> void:
+        get_tree().paused = false
+        win.queue_free()
+        BlessingManager.set_blessing(god_name, blessing)
+        emit_signal("blessing_selected", god_name, blessing)

--- a/scripts/pantheon_fire.gd
+++ b/scripts/pantheon_fire.gd
@@ -1,6 +1,32 @@
 extends Node2D
 
 @onready var _animated_sprite = $Fire
+@onready var _altar_scene: PackedScene = preload("res://scenes/altar.tscn")
+
+var _chosen: Dictionary = {}
+
+func _ready() -> void:
+        _spawn_altars()
+
+func _spawn_altars() -> void:
+        var altar1: GodAltar = _altar_scene.instantiate()
+        altar1.position = Vector2(-100, 20)
+        altar1.god_name = "GodA"
+        altar1.blessings = ["Сила", "Защита"]
+        add_child(altar1)
+        altar1.blessing_selected.connect(_on_blessing_selected)
+
+        var altar2: GodAltar = _altar_scene.instantiate()
+        altar2.position = Vector2(100, 20)
+        altar2.god_name = "GodB"
+        altar2.blessings = ["Мудрость", "Удача"]
+        add_child(altar2)
+        altar2.blessing_selected.connect(_on_blessing_selected)
+
+func _on_blessing_selected(god: String, blessing: String) -> void:
+        _chosen[god] = blessing
+        if _chosen.size() >= 2:
+                TransitionManager.change_scene("res://scenes/Levels/kingdom_king.tscn")
 
 func _process(delta: float) -> void:
-	_animated_sprite.play("fire")
+        _animated_sprite.play("fire")


### PR DESCRIPTION
## Summary
- add BlessingManager autoload
- implement GodAltar script and an altar scene
- spawn two altars in `pantheon_fire.gd`
- transition to `kingdom_king` scene after blessings selected

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6853d00bad94832599119e2f3e1f4e75