### PR TITLE
Fix unpause logic for altar menu

### DIFF
--- a/scripts/god_altar.gd
+++ b/scripts/god_altar.gd
@@ -7,28 +7,37 @@ signal blessing_selected(god: String, blessing: String)
 
 @export var god_name: String = "God"
 
+# Tracks whether the game tree was already paused before showing the
+# blessing selection window. Used to avoid unpausing the tree if it was
+# previously paused by another system.
+var _tree_was_paused := false
+
 
 func interact(_player: Node) -> void:
 	_show_menu()
 
 
 func _show_menu() -> void:
-	var win := Window.new()
-	win.title = "Выберите благословение"
-	var vbox := VBoxContainer.new()
-	win.add_child(vbox)
+        var win := Window.new()
+        win.pause_mode = Node.PAUSE_MODE_PROCESS
+        win.title = "Выберите благословение"
+        var vbox := VBoxContainer.new()
+        win.add_child(vbox)
 	for b in blessings:
 		var btn := Button.new()
 		btn.text = b
 		btn.pressed.connect(_on_blessing_chosen.bind(b, win))
 		vbox.add_child(btn)
-	add_child(win)
-	get_tree().paused = true
-	win.popup_centered(Vector2(200, 100))
+        add_child(win)
+        _tree_was_paused = get_tree().paused
+        if not _tree_was_paused:
+                get_tree().paused = true
+        win.popup_centered(Vector2(200, 100))
 
 
 func _on_blessing_chosen(blessing: String, win: Window) -> void:
-	get_tree().paused = false
-	win.queue_free()
-	BlessingManager.set_blessing(god_name, blessing)
-	emit_signal("blessing_selected", god_name, blessing)
+        if not _tree_was_paused:
+                get_tree().paused = false
+        win.queue_free()
+        BlessingManager.set_blessing(god_name, blessing)
+        emit_signal("blessing_selected", god_name, blessing)


### PR DESCRIPTION
## Summary
- keep blessing selection window active while the game is paused
- only pause the tree when opening the blessing menu if not already paused

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6853e31dd5248325ad2eb1db3f80bc68