### PR TITLE
Add full-screen inventory with three tabs

### DIFF
--- a/scenes/HUD.tscn
+++ b/scenes/HUD.tscn
@@ -77,14 +77,14 @@ layout_mode = 2
 [node name="InventoryPanel" type="Panel" parent="HUD"]
 layout_mode = 1
 anchors_preset = -1
-anchor_left = 0.25
-anchor_top = 0.25
-anchor_right = 0.75
-anchor_bottom = 0.75
-offset_left = 210.5
-offset_top = 79.25
-offset_right = 173.5
-offset_bottom = 93.75
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
 
 [node name="InfoTabs" type="TabContainer" parent="HUD/InventoryPanel"]
 layout_mode = 1
@@ -95,21 +95,28 @@ grow_horizontal = 2
 grow_vertical = 2
 current_tab = 0
 
-[node name="InventoryTab" type="VBoxContainer" parent="HUD/InventoryPanel/InfoTabs"]
+[node name="Задания гильдии" type="VBoxContainer" parent="HUD/InventoryPanel/InfoTabs"]
 layout_mode = 2
 metadata/_tab_index = 0
 
-[node name="InventoryGrid" type="GridContainer" parent="HUD/InventoryPanel/InfoTabs/InventoryTab"]
+[node name="QuestsList" type="ItemList" parent="HUD/InventoryPanel/InfoTabs/Задания гильдии"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="Снаряжение" type="VBoxContainer" parent="HUD/InventoryPanel/InfoTabs"]
+layout_mode = 2
+metadata/_tab_index = 1
+
+[node name="InventoryGrid" type="GridContainer" parent="HUD/InventoryPanel/InfoTabs/Снаряжение"]
 layout_mode = 2
 size_flags_vertical = 3
 columns = 5
 
-[node name="StatsTab" type="VBoxContainer" parent="HUD/InventoryPanel/InfoTabs"]
-visible = false
+[node name="Характеристики" type="VBoxContainer" parent="HUD/InventoryPanel/InfoTabs"]
 layout_mode = 2
-metadata/_tab_index = 1
+metadata/_tab_index = 2
 
-[node name="BlessingsList" type="ItemList" parent="HUD/InventoryPanel/InfoTabs/StatsTab"]
+[node name="BlessingsList" type="ItemList" parent="HUD/InventoryPanel/InfoTabs/Характеристики"]
 layout_mode = 2
 size_flags_vertical = 3
 

--- a/scripts/hud.gd
+++ b/scripts/hud.gd
@@ -11,8 +11,9 @@ var mp_orb: OrbUIController
 
 # Инвентарь
 @onready var inventory_panel: Control = $HUD/InventoryPanel
-@onready var inventory_grid: GridContainer = $HUD/InventoryPanel/InfoTabs/InventoryTab/InventoryGrid
-@onready var blessings_list: ItemList = $HUD/InventoryPanel/InfoTabs/StatsTab/BlessingsList
+@onready var inventory_grid: GridContainer = $HUD/InventoryPanel/InfoTabs/Снаряжение/InventoryGrid
+@onready var blessings_list: ItemList = $HUD/InventoryPanel/InfoTabs/Характеристики/BlessingsList
+@onready var quests_list: ItemList = $HUD/InventoryPanel/InfoTabs/Задания гильдии/QuestsList
 @onready var inventory: Inventory = $Inventory
 
 func _ready() -> void:


### PR DESCRIPTION
## Summary
- replace small inventory with a fullscreen panel
- add three tabs: "Задания гильдии", "Снаряжение", and "Характеристики"
- update HUD script paths for the new tab names

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685409edea808325bfa55eec9281abe9