### PR TITLE
Add cave level with Exit

### DIFF
--- a/scenes/Levels/cave_level.gd
+++ b/scenes/Levels/cave_level.gd
@@ -1,0 +1,12 @@
+extends Node
+
+func _ready() -> void:
+    # Ensure the exit is positioned at the player spawn point
+    if has_node("Player/Player") and has_node("Exit"):
+        $Exit.position = $Player/Player.position
+
+func _on_exit_body_entered(body: Node2D) -> void:
+    if body.name == "Player":
+        body.set_process(false)
+        TransitionManager.change_scene("res://scenes/Main.tscn")
+

--- a/scenes/Levels/cave_level.tscn
+++ b/scenes/Levels/cave_level.tscn
@@ -1,0 +1,175 @@
+[gd_scene load_steps=19 format=3 uid="uid://citgr4h7kjmw2"]
+
+[ext_resource type="PackedScene" uid="uid://dolm0awkrgl7m" path="res://scenes/player.tscn" id="1"]
+[ext_resource type="Script" uid="uid://bo8rt7s20wgyr" path="res://scenes/Levels/cave_level.gd" id="1_3p2gp"]
+[ext_resource type="Texture2D" uid="uid://dd63kst26r5ds" path="res://assets/parallax_bg/paralax_bg_1_sky.png" id="3_q8u5g"]
+[ext_resource type="Texture2D" uid="uid://bmn82hvqpj7sw" path="res://assets/parallax_bg/paralax_bg_2_smallClouds.png" id="4_lhr70"]
+[ext_resource type="Script" uid="uid://dnjdjvavi217w" path="res://scripts/small_clouds.gd" id="4_wp0k4"]
+[ext_resource type="Texture2D" uid="uid://bet4f50wgjens" path="res://assets/parallax_bg/paralax_bg_3_mountains.png" id="5_wp0k4"]
+[ext_resource type="Texture2D" uid="uid://b12lox3xgffwy" path="res://assets/parallax_bg/paralax_bg_4_bigClouds.png" id="6_bjd11"]
+[ext_resource type="Script" uid="uid://odaxpu7ubwei" path="res://scripts/big_clouds.gd" id="6_lhr70"]
+[ext_resource type="Texture2D" uid="uid://du2iwna3rn7ak" path="res://assets/parallax_bg/paralax_bg_5_forest.png" id="7_qmy6f"]
+[ext_resource type="Texture2D" uid="uid://d05y3myd7kinb" path="res://assets/parallax_bg/paralax_bg_6_farBushes.png" id="8_mwfav"]
+[ext_resource type="Texture2D" uid="uid://bol37tybjqnvr" path="res://assets/parallax_bg/paralax_bg_7_nearBushes.png" id="9_3p2gp"]
+[ext_resource type="Material" uid="uid://g2dorm25n1m5" path="res://shaders/wind_material.tres" id="10_1nqs0"]
+[ext_resource type="PackedScene" uid="uid://jubqgarq03kq" path="res://scenes/fog_layer.tscn" id="12_bjd11"]
+[ext_resource type="Shader" uid="uid://cq0tvmh3a0lof" path="res://shaders/god_rays.gdshader" id="13_qmy6f"]
+[ext_resource type="TileSet" uid="uid://c863tgpflukmr" path="res://assets/tilesets/nature.tres" id="15_nfivy"]
+[ext_resource type="PackedScene" uid="uid://i60btftcy6ji" path="res://scenes/HUD.tscn" id="17_ft6cd"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_mwfav"]
+shader = ExtResource("13_qmy6f")
+shader_parameter/light_pos = Vector2(0.5, 0.2)
+shader_parameter/decay = 0.95
+shader_parameter/samples = 30
+shader_parameter/weight = 0.5
+shader_parameter/threshold = 0.6
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_exit"]
+size = Vector2(32, 32)
+
+
+[node name="Main" type="Node"]
+script = ExtResource("1_3p2gp")
+
+[node name="Player" type="CanvasLayer" parent="."]
+layer = 2
+follow_viewport_enabled = true
+
+[node name="Player" parent="Player" instance=ExtResource("1")]
+z_index = 2
+position = Vector2(-1, -13)
+speed = 800.0
+metadata/_edit_group_ = true
+
+[node name="Camera2D" type="Camera2D" parent="Player/Player"]
+position = Vector2(0, -62)
+limit_smoothed = true
+position_smoothing_enabled = true
+drag_left_margin = 0.0
+drag_top_margin = 0.0
+drag_right_margin = 0.0
+drag_bottom_margin = 0.0
+
+
+[node name="ParallaxBackground" type="ParallaxBackground" parent="."]
+
+[node name="Sky" type="ParallaxLayer" parent="ParallaxBackground"]
+position = Vector2(-375, -973)
+motion_scale = Vector2(0.1, 0.4)
+motion_mirroring = Vector2(746, 0)
+metadata/_edit_group_ = true
+
+[node name="Sprite2D" type="Sprite2D" parent="ParallaxBackground/Sky"]
+texture = ExtResource("3_q8u5g")
+centered = false
+
+[node name="SmallClouds" type="ParallaxLayer" parent="ParallaxBackground"]
+position = Vector2(-375, -973)
+motion_scale = Vector2(0.15, 0.5)
+motion_mirroring = Vector2(746, 0)
+script = ExtResource("4_wp0k4")
+metadata/_edit_group_ = true
+
+[node name="Sprite2D" type="Sprite2D" parent="ParallaxBackground/SmallClouds"]
+texture = ExtResource("4_lhr70")
+centered = false
+
+[node name="Mountains" type="ParallaxLayer" parent="ParallaxBackground"]
+position = Vector2(-375, -973)
+motion_scale = Vector2(0.2, 0.6)
+motion_mirroring = Vector2(746, 0)
+metadata/_edit_group_ = true
+
+[node name="Sprite2D" type="Sprite2D" parent="ParallaxBackground/Mountains"]
+texture = ExtResource("5_wp0k4")
+centered = false
+
+[node name="BigClouds" type="ParallaxLayer" parent="ParallaxBackground"]
+position = Vector2(-453, -1183)
+motion_mirroring = Vector2(746, 0)
+script = ExtResource("6_lhr70")
+scroll_speed = Vector2(7, 0)
+metadata/_edit_group_ = true
+
+[node name="Sprite2D" type="Sprite2D" parent="ParallaxBackground/BigClouds"]
+position = Vector2(0, 396)
+scale = Vector2(0.6, 0.6)
+texture = ExtResource("6_bjd11")
+centered = false
+
+[node name="Forest" type="ParallaxLayer" parent="ParallaxBackground"]
+position = Vector2(-375, -973)
+motion_scale = Vector2(0.4, 0.7)
+motion_mirroring = Vector2(746, 0)
+metadata/_edit_group_ = true
+
+[node name="Sprite2D" type="Sprite2D" parent="ParallaxBackground/Forest"]
+material = ExtResource("10_1nqs0")
+texture = ExtResource("7_qmy6f")
+centered = false
+
+[node name="FarBushes" type="ParallaxLayer" parent="ParallaxBackground"]
+position = Vector2(-375, -973)
+motion_scale = Vector2(0.5, 0.8)
+motion_mirroring = Vector2(746, 0)
+metadata/_edit_group_ = true
+
+[node name="Sprite2D" type="Sprite2D" parent="ParallaxBackground/FarBushes"]
+material = ExtResource("10_1nqs0")
+texture = ExtResource("8_mwfav")
+centered = false
+
+[node name="NearBushes" type="ParallaxLayer" parent="ParallaxBackground"]
+position = Vector2(-375, -985)
+motion_scale = Vector2(0.7, 0.9)
+motion_mirroring = Vector2(746, 0)
+metadata/_edit_group_ = true
+
+[node name="Sprite2D" type="Sprite2D" parent="ParallaxBackground/NearBushes"]
+material = ExtResource("10_1nqs0")
+texture = ExtResource("9_3p2gp")
+centered = false
+
+[node name="ColorRect" type="ColorRect" parent="ParallaxBackground"]
+material = SubResource("ShaderMaterial_mwfav")
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ParallaxForeground" type="ParallaxBackground" parent="."]
+layer = 1
+
+[node name="BigClouds" type="ParallaxLayer" parent="ParallaxForeground"]
+position = Vector2(-342, -1393)
+motion_mirroring = Vector2(746, 0)
+script = ExtResource("6_lhr70")
+metadata/_edit_group_ = true
+
+[node name="Sprite2D" type="Sprite2D" parent="ParallaxForeground/BigClouds"]
+texture = ExtResource("6_bjd11")
+centered = false
+
+[node name="Fog" type="ParallaxLayer" parent="ParallaxForeground"]
+position = Vector2(-375, -138)
+motion_mirroring = Vector2(746, 0)
+metadata/_edit_group_ = true
+
+[node name="FogLayer" parent="ParallaxForeground/Fog" instance=ExtResource("12_bjd11")]
+texture_filter = 1
+texture_repeat = 3
+
+[node name="WorldMap" type="TileMapLayer" parent="."]
+tile_set = ExtResource("15_nfivy")
+
+[node name="HUD" parent="." instance=ExtResource("17_ft6cd")]
+layer = 100
+
+[node name="Exit" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Exit"]
+position = Vector2(-1, -13)
+shape = SubResource("RectangleShape2D_exit")
+
+[connection signal="body_entered" from="Exit" to="." method="_on_exit_body_entered"]


### PR DESCRIPTION
## Summary
- duplicate `Main.tscn` as new level `cave_level.tscn`
- remove Enemy layer from new level
- add Exit area with collision shape at the spawn location
- create `cave_level.gd` script handling exit to main scene

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68546d2d0fe0832587b378e22e8f4f54