### PR TITLE
Add method for positioning player

### DIFF
--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -146,6 +146,11 @@ func respawn() -> void:
 	set_process(true)
 
 
+# Allows external scripts to place the player at a given position
+func set_spawn_position(pos: Vector2) -> void:
+       position = pos
+
+
 func health_regen(delta: float) -> void:
 	if health < max_health:
 		var prev := int(health)


### PR DESCRIPTION
## Summary
- document the new `set_spawn_position()` method in Player script
- let world map and cave world use this method to reliably place the player

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_e_68547275ec748325a7cc519df630fb75