### PR TITLE
Add exit handler for cave world

### DIFF
--- a/scripts/cave_world.gd
+++ b/scripts/cave_world.gd
@@ -161,5 +161,13 @@ func position_to_cell(global_pos: Vector2) -> Vector2i:
 
 
 func _on_player_died() -> void:
-	await get_tree().create_timer(2).timeout
-	get_tree().reload_current_scene()
+        await get_tree().create_timer(2).timeout
+        get_tree().reload_current_scene()
+
+
+# When the player enters the exit Area2D we return back to the previous scene.
+# This is similar to other level scripts where the player is disabled and a
+# transition effect is triggered.
+func _on_exit_body_entered(body: Node2D) -> void:
+        if body.name == "Player":
+                TransitionManager.change_scene("res://scenes/Main.tscn")


### PR DESCRIPTION
## Summary
- add exit body handler in `cave_world.gd`
- ensure `Exit` in `cave_level.tscn` connects to handler

## Testing
- `godot` was not available so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_6854828ecb14832591cc2d69a04de882